### PR TITLE
(#15) Add session config helper functions

### DIFF
--- a/lightning-haskell.cabal
+++ b/lightning-haskell.cabal
@@ -65,6 +65,7 @@ test-suite lightning-haskell-test
                      , hspec
                      , text
                      , transformers
+  other-modules:       Web.LightningSpec
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,1 @@
-main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/test/Web/LightningSpec.hs
+++ b/test/Web/LightningSpec.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Web.LightningSpec where
+
+import           Test.Hspec
+
+import           Data.Maybe
+
+import           Web.Lightning
+import           Web.Lightning.Session
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "Lightning options API" $ do
+    it "allows setting a session name" $ do
+      let opts = setSessionName "test" defaultLightningOptions
+          sess = fromJust $ optSession opts
+       in fromJust (snName sess) `shouldBe` "test"
+    it "allows setting a session id" $ do
+      let opts = setSessionId "abc-xyz" defaultLightningOptions
+          sess = fromJust $ optSession opts
+       in snId sess `shouldBe` "abc-xyz"


### PR DESCRIPTION
As of https://github.com/cmoresid/lightning-haskell/commit/18f27da5190682fb80eab3e28705e4d35ad9ea69 new, named sessions cannot be created. Passing-in a session to `runLightning` (or through a `LightningOptions` value to `runLightningWith`) implies either setting up an existing session or assuming a new one, with a server-baked name.

I've made as few changes as possible to tackle this and #15, allowing to setup session overrides of `LightningOptions` defaults. 

Anyway, if `createSession` is to be invoked within `runResumeLightningWith`, depending on passed-in opts, it'd be preferable to exclude it from the DSL

Maybe all -or part- of this departs from your design plans so, needless to say, add, change, drop or let me know how can I improve it :)

Cheers!
