### PR TITLE
Add HTTP Basic Authentication support (#13)

### DIFF
--- a/test/Web/LightningSpec.hs
+++ b/test/Web/LightningSpec.hs
@@ -23,3 +23,7 @@ spec = do
       let opts = setSessionId "abc-xyz" defaultLightningOptions
           sess = fromJust $ optSession opts
        in snId sess `shouldBe` "abc-xyz"
+    it "allows setting HTTP Basic Auth credentials" $ do
+      let opts = setBasicAuth ("user", "secret") defaultLightningOptions
+          (BasicAuth (_, p)) = optLoginMethod opts
+       in p `shouldBe` "secret"


### PR DESCRIPTION
Hi Connor!

I've added support for authenticating against a server using HTTP Basic Authentication (i.e.: a server running with `LIGHTNING_USERNAME` and `LIGHTNING_PASSWORD` on). Added `setBasicAuth` helper as well to set the `optLoginMethod` in the `LightningOptions` record.

Hope you find it useful!

Cheers!
