### PR TITLE
Add helper to override base URL

### DIFF
--- a/src/Web/Lightning.hs
+++ b/src/Web/Lightning.hs
@@ -23,6 +23,7 @@ module Web.Lightning
   , runResumeLightningtWith
   -- * Client configuration
   , defaultLightningOptions
+  , setBaseURL
   , setSessionName
   , setSessionId
   , setBasicAuth
@@ -87,6 +88,14 @@ instance Default LightningOptions where
 -- | Defines the default lightning-viz options.
 defaultLightningOptions :: LightningOptions
 defaultLightningOptions = def
+
+-- | Sets the base URL of Lightning's API in the given
+-- 'LightningOptions' record.
+setBaseURL :: T.Text
+           -- ^ Fully qualified API base URL
+           -> LightningOptions
+           -> LightningOptions
+setBaseURL url opts = opts { optHostUrl = url }
 
 -- | Sets the name of the session that is nested in the
 -- given 'LightningOptions' record.

--- a/test/Web/LightningSpec.hs
+++ b/test/Web/LightningSpec.hs
@@ -15,6 +15,9 @@ main = hspec spec
 spec :: Spec
 spec = do
   describe "Lightning options API" $ do
+    it "allows setting Lightning's API base URL" $ do
+      let opts = setBaseURL "http://127.0.0.1:3000" defaultLightningOptions
+       in optHostUrl opts `shouldBe` "http://127.0.0.1:3000"
     it "allows setting a session name" $ do
       let opts = setSessionName "test" defaultLightningOptions
           sess = fromJust $ optSession opts


### PR DESCRIPTION
Hi Connor!

Minor addition; helper for modifying the default base URL in the `LightningOptions` record.

Cheers!
