### PR TITLE
Updated monad transformer stack to include ReaderT.

### DIFF
--- a/lightning-haskell.cabal
+++ b/lightning-haskell.cabal
@@ -45,6 +45,7 @@ library
                      , bytestring
                      , data-default-class
                      , free
+                     , mtl
                      , http-client
                      , http-client-tls
                      , http-types

--- a/src/Web/Lightning/Plots/Adjacency.hs
+++ b/src/Web/Lightning/Plots/Adjacency.hs
@@ -10,6 +10,8 @@ module Web.Lightning.Plots.Adjacency
   where
 
 --------------------------------------------------------------------------------
+import           Control.Monad.Reader
+
 import           Data.Aeson
 import           Data.Default.Class
 import qualified Data.Text                         as T
@@ -22,19 +24,19 @@ import           Web.Lightning.Utilities
 
 -- | Adjacency plot parameters
 data AdjacencyPlot =
-  AdjacencyPlot { apConn   :: [[Double]]
+  AdjacencyPlot { apConn      :: [[Double]]
                   -- ^ Matrix that defines the connectivity of the plot. The
                   -- dimensions of the matrix can be (n, n), (n, 2) or (n, 3).
                   -- Matrix can be binary or continuous valued. Links should
                   -- contain either 2 elements per link (source, target) or
                   -- 3 elements (source, target, value).
-                , apLabels :: Maybe [T.Text]
+                , apLabels    :: Maybe [T.Text]
                   -- ^ Text labels for each item (will label rows and columns).
-                , apGroup  :: Maybe [Int]
+                , apGroup     :: Maybe [Int]
                   -- ^ List to set colors via groups.
-                , apSort   :: Maybe T.Text
+                , apSort      :: Maybe T.Text
                   -- ^ What to sort by; options are "group" or "degree."
-                , apNumbers :: Maybe Bool
+                , apNumbers   :: Maybe Bool
                   -- ^ Whether or not to show numbers on cells.
                 , apSymmetric :: Maybe Bool
                   -- ^ Whether or not to make links symetrical.
@@ -64,12 +66,11 @@ instance ValidatablePlot AdjacencyPlot where
 -- a sparse adjacency matrix visualiazation.
 --
 -- <http://lightning-viz.org/visualizations/adjacency/ Adjacency Visualization>
-adjacencyPlot :: Monad m => T.Text
-                            -- ^ Base URL for lightning-viz server.
-                         -> AdjacencyPlot
+adjacencyPlot :: Monad m => AdjacencyPlot
                             -- ^ Adjacency plot to create.
                          -> LightningT m Visualization
                             -- ^ Transformer stack with created visualization.
-adjacencyPlot bUrl adjPlt = do
+adjacencyPlot adjPlt = do
+  url <- ask
   viz <- sendPlot "adjacency" adjPlt R.plot
-  return $ viz { vizBaseUrl = Just bUrl }
+  return $ viz { vizBaseUrl = Just url }

--- a/src/Web/Lightning/Plots/Circle.hs
+++ b/src/Web/Lightning/Plots/Circle.hs
@@ -8,6 +8,8 @@ module Web.Lightning.Plots.Circle
   ) where
 
 --------------------------------------------------------------------------------
+import           Control.Monad.Reader
+
 import           Data.Aeson
 import           Data.Default.Class
 import qualified Data.Text                         as T
@@ -60,12 +62,11 @@ instance ValidatablePlot CirclePlot where
 -- a scatter plot.
 --
 -- <http://lightning-viz.org/visualizations/circle/ Circle Visualization>
-circlePlot :: Monad m => T.Text
-                          -- ^ Base URL for lightning-viz server.
-                      -> CirclePlot
+circlePlot :: Monad m => CirclePlot
                         -- ^ Circle plot to create.
                       -> LightningT m Visualization
                         -- ^ Transformer stack with created visualization.
-circlePlot bUrl circlePlt = do
+circlePlot circlePlt = do
+  url <- ask
   viz <- sendPlot "circle" circlePlt R.plot
-  return $ viz { vizBaseUrl = Just bUrl }
+  return $ viz { vizBaseUrl = Just url }

--- a/src/Web/Lightning/Plots/Force.hs
+++ b/src/Web/Lightning/Plots/Force.hs
@@ -10,6 +10,8 @@ module Web.Lightning.Plots.Force
   where
 
 --------------------------------------------------------------------------------
+import           Control.Monad.Reader
+
 import           Data.Aeson
 import           Data.Default.Class
 import qualified Data.Text                         as T
@@ -80,12 +82,11 @@ instance ValidatablePlot ForcePlot where
 -- force-directed network visualization from connectivity.
 --
 -- <http://lightning-viz.org/visualizations/force/ Force-Directed Network Visualization>
-forcePlot :: Monad m => T.Text
-                        -- ^ Base URL for lightning-viz server.
-                     -> ForcePlot
+forcePlot :: Monad m => ForcePlot
                         -- ^ Force plot to create.
                      -> LightningT m Visualization
                         -- ^ Transformer stack with created visualization.
-forcePlot bUrl forcePlt = do
+forcePlot forcePlt = do
+  url <- ask
   viz <- sendPlot "force" forcePlt R.plot
-  return $ viz { vizBaseUrl = Just bUrl }
+  return $ viz { vizBaseUrl = Just url }

--- a/src/Web/Lightning/Plots/Graph.hs
+++ b/src/Web/Lightning/Plots/Graph.hs
@@ -10,6 +10,8 @@ module Web.Lightning.Plots.Graph
   where
 
 --------------------------------------------------------------------------------
+import           Control.Monad.Reader
+
 import           Data.Aeson
 import           Data.Default.Class
 import qualified Data.Text                         as T
@@ -83,12 +85,11 @@ instance ValidatablePlot GraphPlot where
 
 -- | Submits a request to the specified lightning-viz server to create a
 -- node-link graph from spatial points and their connectivity.
-graphPlot :: Monad m => T.Text
-                        -- ^ Base URL for lightning-viz server.
-                     -> GraphPlot
+graphPlot :: Monad m => GraphPlot
                         -- ^ Graph plot to create.
                      -> LightningT m Visualization
                         -- ^ Transformer stack with created visualization.
-graphPlot bUrl graphPlt = do
+graphPlot graphPlt = do
+  url <- ask
   viz <- sendPlot "graph" graphPlt R.plot
-  return $ viz { vizBaseUrl = Just bUrl }
+  return $ viz { vizBaseUrl = Just url }

--- a/src/Web/Lightning/Plots/GraphBundled.hs
+++ b/src/Web/Lightning/Plots/GraphBundled.hs
@@ -10,7 +10,7 @@ module Web.Lightning.Plots.GraphBundled
   where
 
 --------------------------------------------------------------------------------
-import           Data.Text                         as T
+import           Control.Monad.Reader
 
 import qualified Web.Lightning.Routes              as R
 import           Web.Lightning.Plots.Graph         (GraphPlot(..))
@@ -20,12 +20,11 @@ import           Web.Lightning.Types.Visualization (Visualization (..))
 
 -- | Submits a request to the specified lightning-viz server to create a
 -- bundled node-link graph visualization.
-graphBundledPlot :: Monad m => T.Text
-                               -- ^ Base URL for lightning-viz server.
-                            -> GraphPlot
+graphBundledPlot :: Monad m => GraphPlot
                                -- ^ Graph plot to create.
                             -> LightningT m Visualization
                                -- ^ Transformer stack with created visualization.
-graphBundledPlot bUrl graphPlt = do
+graphBundledPlot graphPlt = do
+  url <- ask
   viz <- sendPlot "graph-bundled" graphPlt R.plot
-  return $ viz { vizBaseUrl = Just bUrl }
+  return $ viz { vizBaseUrl = Just url }

--- a/src/Web/Lightning/Plots/Histogram.hs
+++ b/src/Web/Lightning/Plots/Histogram.hs
@@ -10,9 +10,10 @@ module Web.Lightning.Plots.Histogram
   where
 
 --------------------------------------------------------------------------------
+import           Control.Monad.Reader
+
 import           Data.Aeson
 import           Data.Default.Class
-import qualified Data.Text                         as T
 
 import qualified Web.Lightning.Routes              as R
 import           Web.Lightning.Types.Lightning
@@ -47,12 +48,11 @@ instance ValidatablePlot HistogramPlot where
 -- to histogram.
 --
 -- <http://lightning-viz.org/visualizations/histogram/ HistogramPlot Visualization>
-histogramPlot :: Monad m => T.Text
-                            -- ^ Base URL for lightning-viz server.
-                         -> HistogramPlot
+histogramPlot :: Monad m => HistogramPlot
                             -- ^ Histogram plot to create.
                          -> LightningT m Visualization
                             -- ^ Transformer stack with created visualization.
-histogramPlot bUrl histPlt = do
+histogramPlot histPlt = do
+  url <- ask
   viz <- sendPlot "histogram" histPlt R.plot
-  return $ viz { vizBaseUrl = Just bUrl }
+  return $ viz { vizBaseUrl = Just url }

--- a/src/Web/Lightning/Plots/Line.hs
+++ b/src/Web/Lightning/Plots/Line.hs
@@ -10,6 +10,8 @@ module Web.Lightning.Plots.Line
   where
 
 --------------------------------------------------------------------------------
+import           Control.Monad.Reader
+
 import           Data.Aeson
 import           Data.Default.Class
 import qualified Data.Text                         as T
@@ -70,12 +72,11 @@ instance ValidatablePlot LinePlot where
 -- to visualize one-dimensional series.
 --
 -- <http://lightning-viz.org/visualizations/line/ Line Visualization>
-linePlot :: Monad m => T.Text
-                       -- ^ Base URL for lightning-viz server.
-                    -> LinePlot
+linePlot :: Monad m => LinePlot
                        -- ^ Line plot to create.
                     -> LightningT m Visualization
                        -- ^ Transformer stack with created visualization.
-linePlot bUrl linePlt = do
+linePlot linePlt = do
+  url <- ask
   viz <- sendPlot "line" linePlt R.plot
-  return $ viz { vizBaseUrl = Just bUrl }
+  return $ viz { vizBaseUrl = Just url }

--- a/src/Web/Lightning/Plots/LineStream.hs
+++ b/src/Web/Lightning/Plots/LineStream.hs
@@ -10,6 +10,8 @@ module Web.Lightning.Plots.LineStream
   where
 
 --------------------------------------------------------------------------------
+import           Control.Monad.Reader
+
 import           Data.Aeson
 import           Data.Default.Class
 import qualified Data.Text                         as T
@@ -74,12 +76,11 @@ instance ValidatablePlot LineStreamPlot where
 -- | Plot streaming one-dimensional series data as updating lines.
 --
 -- <http://lightning-viz.org/visualizations/streaming/ Streaming Line Visualization>
-streamingLinePlot :: Monad m => T.Text
-                       -- ^ Base URL for lightning-viz server.
-                    -> LineStreamPlot
-                       -- ^ Line plot to create / update.
-                    -> LightningT m Visualization
-                       -- ^ Transformer stack with created visualization.
-streamingLinePlot bUrl slp = do
-  viz' <- streamPlot (lspVisualization slp) "line-streaming" slp R.plot
-  return $ viz' { vizBaseUrl = Just bUrl }
+streamingLinePlot :: Monad m => LineStreamPlot
+                                -- ^ Line plot to create / update.
+                             -> LightningT m Visualization
+                                -- ^ Transformer stack with created visualization.
+streamingLinePlot slp = do
+  url <- ask
+  viz <- streamPlot (lspVisualization slp) "line-streaming" slp R.plot
+  return $ viz { vizBaseUrl = Just url }

--- a/src/Web/Lightning/Plots/Map.hs
+++ b/src/Web/Lightning/Plots/Map.hs
@@ -10,6 +10,8 @@ module Web.Lightning.Plots.Map
   where
 
 --------------------------------------------------------------------------------
+import           Control.Monad.Reader
+
 import           Data.Aeson
 import           Data.Default.Class
 import qualified Data.Text                         as T
@@ -53,12 +55,11 @@ instance ValidatablePlot MapPlot where
 -- chloropleth map of the world or united states.
 --
 -- <http://lightning-viz.org/visualizations/map/ Map Visualization>
-mapPlot :: Monad m => T.Text
-                      -- ^ Base URL for lightning-viz server.
-                   -> MapPlot
+mapPlot :: Monad m => MapPlot
                       -- ^ Map plot to create.
                    -> LightningT m Visualization
                       -- ^ Transformer stack with created visualization.
-mapPlot bUrl mapPlt = do
+mapPlot mapPlt = do
+  url <- ask
   viz <- sendPlot "map" mapPlt R.plot
-  return $ viz { vizBaseUrl = Just bUrl }
+  return $ viz { vizBaseUrl = Just url }

--- a/src/Web/Lightning/Plots/Matrix.hs
+++ b/src/Web/Lightning/Plots/Matrix.hs
@@ -10,6 +10,8 @@ module Web.Lightning.Plots.Matrix
   where
 
 --------------------------------------------------------------------------------
+import           Control.Monad.Reader
+
 import           Data.Aeson
 import           Data.Default.Class
 import qualified Data.Text                         as T
@@ -57,12 +59,11 @@ instance ValidatablePlot MatrixPlot where
 -- heat map of the given matrix.
 --
 -- <http://lightning-viz.org/visualizations/matrix/ Matrix Visualization>
-matrixPlot :: Monad m => T.Text
-                         -- ^ Base URL for lightning-viz server.
-                      -> MatrixPlot
+matrixPlot :: Monad m => MatrixPlot
                          -- ^ Matrix plot to create.
                       -> LightningT m Visualization
                          -- ^ Transformer stack with created visualization.
-matrixPlot bUrl matrixPlt = do
+matrixPlot matrixPlt = do
+  url <- ask
   viz <- sendPlot "matrix" matrixPlt R.plot
-  return $ viz { vizBaseUrl = Just bUrl }
+  return $ viz { vizBaseUrl = Just url }

--- a/src/Web/Lightning/Plots/Scatter.hs
+++ b/src/Web/Lightning/Plots/Scatter.hs
@@ -10,6 +10,8 @@ module Web.Lightning.Plots.Scatter
   where
 
 --------------------------------------------------------------------------------
+import           Control.Monad.Reader
+
 import           Data.Aeson
 import           Data.Default.Class
 import qualified Data.Text                         as T
@@ -87,12 +89,11 @@ instance ValidatablePlot ScatterPlot where
 -- a scatter plot.
 --
 -- <http://lightning-viz.org/visualizations/adjacency/ Scatter Visualization>
-scatterPlot :: Monad m => T.Text
-                          -- ^ Base URL for lightning-viz server.
-                       -> ScatterPlot
+scatterPlot :: Monad m => ScatterPlot
                           -- ^ Scatter plot to create.
                        -> LightningT m Visualization
                           -- ^ Transformer stack with created visualization.
-scatterPlot bUrl scatterPlt = do
+scatterPlot scatterPlt = do
+  url <- ask
   viz <- sendPlot "scatter" scatterPlt R.plot
-  return $ viz { vizBaseUrl = Just bUrl }
+  return $ viz { vizBaseUrl = Just url }

--- a/src/Web/Lightning/Plots/Scatter3.hs
+++ b/src/Web/Lightning/Plots/Scatter3.hs
@@ -10,8 +10,9 @@ module Web.Lightning.Plots.Scatter3
   where
 
 --------------------------------------------------------------------------------
+import           Control.Monad.Reader
+
 import           Data.Aeson
-import           Data.Text                         as T
 import           Data.Default.Class
 
 import qualified Web.Lightning.Routes              as R
@@ -63,12 +64,11 @@ instance ValidatablePlot Scatter3Plot where
 -- a 3D scatter plot.
 --
 -- <http://lightning-viz.org/visualizations/scatter-3/ Scatter Visualization>
-scatter3Plot :: Monad m => T.Text
-                           -- ^ Base URL for lightning-viz server.
-                        -> Scatter3Plot
+scatter3Plot :: Monad m => Scatter3Plot
                            -- ^ Scatter plot to create
                         -> LightningT m Visualization
                            -- ^ Transformer stack with created visualization.
-scatter3Plot bUrl scatter3Plt = do
+scatter3Plot scatter3Plt = do
+  url <- ask
   viz <- sendPlot "scatter-3" scatter3Plt R.plot
-  return $ viz { vizBaseUrl = Just bUrl }
+  return $ viz { vizBaseUrl = Just url }

--- a/src/Web/Lightning/Plots/ScatterStream.hs
+++ b/src/Web/Lightning/Plots/ScatterStream.hs
@@ -10,6 +10,8 @@ module Web.Lightning.Plots.ScatterStream
   where
 
 --------------------------------------------------------------------------------
+import           Control.Monad.Reader
+
 import           Data.Aeson
 import           Data.Default.Class
 import qualified Data.Text                         as T
@@ -89,12 +91,11 @@ instance ValidatablePlot ScatterStreamPlot where
 -- to highlight the most recent data and fade old data away.
 --
 -- <http://lightning-viz.org/visualizations/streaming/ Streaming Scatter Visualization>
-streamingScatterPlot :: Monad m => T.Text
-                       -- ^ Base URL for lightning-viz server.
-                    -> ScatterStreamPlot
-                       -- ^ Scatter plot to create / update.
-                    -> LightningT m Visualization
-                       -- ^ Transformer stack with created visualization.
-streamingScatterPlot bUrl slp = do
+streamingScatterPlot :: Monad m => ScatterStreamPlot
+                                   -- ^ Scatter plot to create / update.
+                                -> LightningT m Visualization
+                                   -- ^ Transformer stack with created visualization.
+streamingScatterPlot slp = do
+  url <- ask
   viz' <- streamPlot (sspVisualization slp) "scatter-streaming" slp R.plot
-  return $ viz' { vizBaseUrl = Just bUrl }
+  return $ viz' { vizBaseUrl = Just url }

--- a/test-integration/Web/Lightning/PlotSpec.hs
+++ b/test-integration/Web/Lightning/PlotSpec.hs
@@ -29,42 +29,41 @@ spec = do
 
   describe "Lightning Integration Tests" $ do
     it "create Adjacency plot." $ do
-      res <- run lightning $ adjacencyPlot url def { apConn = [[1,2,3],[4,5,6],[7,8,9]] }
+      res <- run lightning $ adjacencyPlot def { apConn = [[1,2,3],[4,5,6],[7,8,9]] }
       res `shouldSatisfy` isRight
     it "create Circle plot." $ do
-      res <- run lightning $ circlePlot url def { cpConn = [[1,2,3],[4,5,6],[7,8,9]] }
+      res <- run lightning $ circlePlot def { cpConn = [[1,2,3],[4,5,6],[7,8,9]] }
       res `shouldSatisfy` isRight
     it "create Force plot." $ do
-      res <- run lightning $ forcePlot url def { fpConn = [[1,2,3],[4,5,6],[7,8,9]] }
+      res <- run lightning $ forcePlot def { fpConn = [[1,2,3],[4,5,6],[7,8,9]] }
       res `shouldSatisfy` isRight
     it "create Graph plot." $ do
-      res <- run lightning $ graphPlot url def { gpX = [1,2,3], gpY = [1,2,3], gpConn = [[1,2,3],[4,5,6],[7,8,9]] }
+      res <- run lightning $ graphPlot def { gpX = [1,2,3], gpY = [1,2,3], gpConn = [[1,2,3],[4,5,6],[7,8,9]] }
       res `shouldSatisfy` isRight
     it "create GraphBundled plot." $ do
-      res <- run lightning $ graphPlot url def { gpX = [1,2,3], gpY = [1,2,3], gpConn = [[1,2,3],[4,5,6],[7,8,9]] }
+      res <- run lightning $ graphPlot def { gpX = [1,2,3], gpY = [1,2,3], gpConn = [[1,2,3],[4,5,6],[7,8,9]] }
       res `shouldSatisfy` isRight
     it "create Histogram plot." $ do
-      res <- run lightning $ histogramPlot url def { hpValues = [1,2,2,3,3,3,4,4,5] }
+      res <- run lightning $ histogramPlot def { hpValues = [1,2,2,3,3,3,4,4,5] }
       res `shouldSatisfy` isRight
     it "create Line plot." $ do
-      res <- run lightning $ linePlot url def { lpSeries = [[1,2,3]] }
+      res <- run lightning $ linePlot def { lpSeries = [[1,2,3]] }
       res `shouldSatisfy` isRight
     it "create Map plot." $ do
-      res <- run lightning $ mapPlot url def { mppRegions = ["CAN","USA","MEX"], mppWeights = [13.0,10.0,4.0] }
+      res <- run lightning $ mapPlot def { mppRegions = ["CAN","USA","MEX"], mppWeights = [13.0,10.0,4.0] }
       res `shouldSatisfy` isRight
     it "create Matrix plot." $ do
-      res <- run lightning $ matrixPlot url def { mpMatrix = [[1,1,0],[2,0,0],[3,0,0]] }
+      res <- run lightning $ matrixPlot def { mpMatrix = [[1,1,0],[2,0,0],[3,0,0]] }
       res `shouldSatisfy` isRight
     it "create Scatter plot." $ do
-      res <- run lightning $ scatterPlot url def { spX = [1,2,3], spY = [1,1,1] }
+      res <- run lightning $ scatterPlot def { spX = [1,2,3], spY = [1,1,1] }
       res `shouldSatisfy` isRight
     it "create 3D Scatter plot." $ do
-      res <- run lightning $ scatter3Plot url def { sptX = [1,2,3], sptY = [1,1,1], sptZ = [0,0,0] }
+      res <- run lightning $ scatter3Plot def { sptX = [1,2,3], sptY = [1,1,1], sptZ = [0,0,0] }
       res `shouldSatisfy` isRight
     it "create Streaming line plot." $ do
-      res <- run lightning $ streamingLinePlot url def { lspSeries = [[1,2,3]] }
+      res <- run lightning $ streamingLinePlot def { lspSeries = [[1,2,3]] }
       res `shouldSatisfy` isRight
     it "create Streaming scatter plot." $ do
-      res <- run lightning $ streamingScatterPlot url def { sspX = [1,2,3], sspY = [1,2,3] }
+      res <- run lightning $ streamingScatterPlot def { sspX = [1,2,3], sspY = [1,2,3] }
       res `shouldSatisfy` isRight
-  


### PR DESCRIPTION
Removed the need for the user to pass the lightning-viz server base URL every time you create a plot. The URL is now stored in the monad transformer stack via ReaderT.
